### PR TITLE
Allow __dirname as prefix in require and fs-filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/rules/detect-non-literal-require.js
+++ b/rules/detect-non-literal-require.js
@@ -1,11 +1,30 @@
 /**
  * Tries to detect calls to require with non-literal argument
- * @author Adam Baldwin 
+ * @author Adam Baldwin
  */
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+/**
+ * Returns true if expression is only a literal with __dirname prefix.
+ *
+ * @param node
+ * @returns {boolean}
+ */
+function isLiteralWithDirnamePrefix(node) {
+    "use strict";
+
+    if (node.type === 'BinaryExpression') {
+        return node.left.type === 'Identifier' && node.left.name === '__dirname' && node.right.type === 'Literal';
+    // } else if (node.type === 'TemplateLiteral') { // ES6+
+    //     return node.expressions.length === 1 && node.expressions[0].name === '__dirname' &&
+    //         node.expressions[0].start === node.start + 1
+    }
+
+    return false;
+}
 
 module.exports = function(context) {
 
@@ -15,8 +34,8 @@ module.exports = function(context) {
         "CallExpression": function (node) {
             if (node.callee.name === 'require') {
                 var args = node.arguments;
-                if (args && args.length > 0 && args[0].type !== 'Literal') {
-                    var token = context.getTokens(node)[0];
+                if (args && args.length > 0 && args[0].type !== 'Literal' && !isLiteralWithDirnamePrefix(args[0])) {
+                    //var token = context.getTokens(node)[0];
                     return context.report(node, 'Found non-literal argument in require');
                 }
             }

--- a/test/detect-non-literal-fs-filename.js
+++ b/test/detect-non-literal-fs-filename.js
@@ -3,17 +3,48 @@
 const RuleTester = require('eslint').RuleTester;
 const tester = new RuleTester();
 
-const invalid = 'var a = fs.open(c)';
-
 const ruleName = 'detect-non-literal-fs-filename';
 
-
 tester.run(ruleName, require(`../rules/${ruleName}`), {
-  valid: [{ code: 'var a = fs.open(\'test\')' }],
+  valid: [
+    {
+      code: 'var a = fs.open(\'test\')'
+    },
+    {
+      code: 'var a = fs.open(__dirname + \'/test\')'
+    },
+    // { // ES6+
+    //   code: 'var a = fs.open(`${__dirname}/test`)'
+    // }
+  ],
   invalid: [
     {
-      code: invalid,
+      code: 'var a = fs.open(c)',
       errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
-    }
+    },
+    {
+      code: 'var a = fs.open(\'test\' + __dirname)',
+      errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    },
+    {
+      code: 'var a = fs.open(__dirname + c + \'test\')',
+      errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    },
+    {
+      code: 'var a = fs.open(__dirname + \'test\' + c)',
+      errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    },
+    // { // ES6+
+    //   code: 'var a = fs.open(`${__dirname}${c}/test`)',
+    //   errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    // },
+    // {
+    //   code: 'var a = fs.open(`test${__dirname}`)',
+    //   errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    // },
+    // {
+    //   code: 'var a = fs.open(`${__dirname + c}/test`)',
+    //   errors: [{ message: 'Found fs.open with non literal argument at index 0' }]
+    // }
   ]
 });

--- a/test/detect-non-literal-require.js
+++ b/test/detect-non-literal-require.js
@@ -4,15 +4,47 @@ const RuleTester = require('eslint').RuleTester;
 const tester = new RuleTester();
 
 const ruleName = 'detect-non-literal-require';
-const invalid = 'var a = require(c)';
-
 
 tester.run(ruleName, require(`../rules/${ruleName}`), {
-  valid: [{ code: 'var a = require(\'b\')' }],
+  valid: [
+    {
+      code: 'var a = require(\'b\')'
+    },
+    {
+      code: 'var a = require(__dirname + \'b\')'
+    },
+    // { // ES6+
+    //   code: 'var a = require(`${__dirname}/b`)'
+    // }
+  ],
   invalid: [
     {
-      code: invalid,
+      code: 'var a = require(c)',
       errors: [{ message: 'Found non-literal argument in require' }]
-    }
+    },
+    {
+      code: 'var a = require(\'b\' + __dirname)',
+      errors: [{ message: 'Found non-literal argument in require' }]
+    },
+    {
+      code: 'var a = require(__dirname + c + \'b\')',
+      errors: [{ message: 'Found non-literal argument in require' }]
+    },
+    {
+      code: 'var a = require(__dirname + \'b\' + c)',
+      errors: [{ message: 'Found non-literal argument in require' }]
+    },
+    // { // ES6+
+    //   code: 'var a = require(`${__dirname}${c}/b`)',
+    //   errors: [{ message: 'Found non-literal argument in require' }]
+    // },
+    // {
+    //   code: 'var a = require(`b${__dirname}`)',
+    //   errors: [{ message: 'Found non-literal argument in require' }]
+    // },
+    // {
+    //     code: 'var a = require(`${__dirname + c}/b`)',
+    //   errors: [{ message: 'Found non-literal argument in require' }]
+    // }
   ]
 });


### PR DESCRIPTION
The `__dirname` prefix is very common for `fs` calls and it is safe and removes many false positives for these rules. For our project it removed 370 false positives.

The check for `fs` as caller of `fsFunctions` removed two false positives and it may also remove real findings, so we should discuss about that.

I also added ES6 versions for template strings, but the tests did not work with them so I commented these checks and tests out. They work on our project though.

The linting is completely broken in my clone so if this is still used and I made an error I apologize.

And please don't tell me again this code is replaced already (https://github.com/nodesecurity/nsp/pull/197) :broken_heart: 