### PR TITLE
Add non-literal-require support for TemplateLiteral

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "safe-regex": "^1.1.0"
   },
   "devDependencies": {
+    "babel-eslint": "^8.2.3",
     "changelog": "1.3.0",
     "eslint": "^2.10.1",
     "eslint-config-nodesecurity": "^1.3.1",

--- a/rules/detect-non-literal-require.js
+++ b/rules/detect-non-literal-require.js
@@ -15,7 +15,9 @@ module.exports = function(context) {
         "CallExpression": function (node) {
             if (node.callee.name === 'require') {
                 var args = node.arguments;
-                if (args && args.length > 0 && args[0].type !== 'Literal') {
+                if (args && args.length > 0 &&
+                    (args[0].type === 'TemplateLiteral' && args[0].expressions.length > 0) ||
+                    (args[0].type !== 'TemplateLiteral' && args[0].type !== 'Literal')) {
                     var token = context.getTokens(node)[0];
                     return context.report(node, 'Found non-literal argument in require');
                 }

--- a/test/detect-non-literal-require.js
+++ b/test/detect-non-literal-require.js
@@ -1,17 +1,24 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
+RuleTester.setDefaultConfig({
+    parser: 'babel-eslint'
+});
 const tester = new RuleTester();
-
 const ruleName = 'detect-non-literal-require';
-const invalid = 'var a = require(c)';
-
 
 tester.run(ruleName, require(`../rules/${ruleName}`), {
-  valid: [{ code: 'var a = require(\'b\')' }],
+  valid: [
+      { code: 'var a = require(\'b\')' },
+      { code: 'var a = require(`b`)' }
+  ],
   invalid: [
     {
-      code: invalid,
+      code: 'var a = require(c)',
+      errors: [{ message: 'Found non-literal argument in require' }]
+    },
+    {
+      code: 'var a = require(`${c}`)',
       errors: [{ message: 'Found non-literal argument in require' }]
     }
   ]


### PR DESCRIPTION
Currently following code triggers the detect-non-literal-require rule:

```js
const foo = require(`bar`)
```

However it would be more accurate (and less noisey) if it triggered on
cases such as:

```js
const foo = require(`${bar}`)
```