### PR TITLE
Expand scope of detect-possible-timing-attack

### DIFF
--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -18,7 +18,19 @@ var keywords = '((' + [
     'hash'
 ].join(')|(') + '))';
 
-var re = new RegExp('^' + keywords + '$', 'im');
+var re = new RegExp('^.*' + keywords + '.*$', 'im');
+
+/**
+ * Maps type to what to handler function
+ * Returns true if it can have a timing attack, false otherwise
+ */
+const isVulnHandlers = {
+    'CallExpression': isVulnCallExpression,
+    'Identifier': isVulnIdentifier,
+    'Literal': isVulnLiteral,
+    'MemberExpression': isVulnMemberExpression,
+    // Not exhaustive, but covers most cases. Does not cover ConditionalExpressions, for example
+}
 
 function containsKeyword (node) {
     if (node.type === 'Identifier') {
@@ -29,28 +41,39 @@ function containsKeyword (node) {
     return
 }
 
+function isVulnerable(node) {
+    return node && node.type && isVulnHandlers.hasOwnProperty(node.type) && isVulnHandlers[node.type](node);
+}
+
+function isVulnCallExpression(node) {
+    return isVulnerable(node.callee);
+}
+
+function isVulnIdentifier (node) {
+    return containsKeyword(node);
+}
+
+function isVulnLiteral (node) {
+    // String is the only Literal that can have a secret in it
+    return typeof node.value === 'string';
+}
+
+function isVulnMemberExpression (node) {
+    // If anything along the path is prohibited, it could be problematic
+    // ex: password.toString() could be one, so could user.password
+    return isVulnerable(node.object) || isVulnerable(node.property);
+}
+
 module.exports = function(context) {
 
     "use strict";
 
     return {
-        "IfStatement": function(node) {
-            if (node.test && node.test.type === 'BinaryExpression') {
-                if (node.test.operator === '==' || node.test.operator === '===' || node.test.operator === '!=' || node.test.operator === '!==') {
+        "BinaryExpression": function(node) {
+            if (node.operator === '==' || node.operator === '===' || node.operator === '!=' || node.operator === '!==') {
 
-                    if (node.test.left) {
-                        var left = containsKeyword(node.test.left);
-                        if (left) {
-                            return context.report(node, "Potential timing attack, left side: " + left);
-                        }
-                    }
-
-                    if (node.test.right) {
-                        var right = containsKeyword(node.test.right);
-                        if (right) {
-                            return context.report(node, "Potential timing attack, right side: " + right);
-                        }
-                    }
+                if (isVulnerable(node.left) && isVulnerable(node.right)) {
+                    return context.report(node, "Potential timing attack");
                 }
             }
         }

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -13,6 +13,7 @@ var keywords = '((' + [
     'api',
     'apiKey',
     'token',
+    'auth',
     'pass',
     'hash'
 ].join(')|(') + '))';

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -37,8 +37,6 @@ module.exports = function(context) {
             if (node.test && node.test.type === 'BinaryExpression') {
                 if (node.test.operator === '==' || node.test.operator === '===' || node.test.operator === '!=' || node.test.operator === '!==') {
 
-                    var token = context.getTokens(node)[0];
-
                     if (node.test.left) {
                     var left = containsKeyword(node.test.left);
                         if (left) {

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -13,7 +13,6 @@ var keywords = '((' + [
     'api',
     'apiKey',
     'token',
-    'auth',
     'pass',
     'hash'
 ].join(')|(') + '))';

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -22,10 +22,11 @@ var re = new RegExp('^' + keywords + '$', 'im');
 
 function containsKeyword (node) {
     if (node.type === 'Identifier') {
-        if (re.test(node.name))
+        if (re.test(node.name)) {
             return true;
         }
-        return
+    }
+    return
 }
 
 module.exports = function(context) {
@@ -38,14 +39,14 @@ module.exports = function(context) {
                 if (node.test.operator === '==' || node.test.operator === '===' || node.test.operator === '!=' || node.test.operator === '!==') {
 
                     if (node.test.left) {
-                    var left = containsKeyword(node.test.left);
+                        var left = containsKeyword(node.test.left);
                         if (left) {
                             return context.report(node, "Potential timing attack, left side: " + left);
                         }
                     }
 
                     if (node.test.right) {
-                    var right = containsKeyword(node.test.right);
+                        var right = containsKeyword(node.test.right);
                         if (right) {
                             return context.report(node, "Potential timing attack, right side: " + right);
                         }

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -20,10 +20,36 @@ var keywords = '((' + [
 
 var re = new RegExp('^.*' + keywords + '.*$', 'im');
 
-/**
- * Maps type to what to handler function
- * Returns true if it can have a timing attack, false otherwise
- */
+const containsKeywordHandlers = {
+    'CallExpression': containsKeywordCallExpression,
+    'Identifier': containsKeywordIdentifier,
+    'MemberExpression': containsKeywordMemberExpression,
+    // Not exhaustive, but covers most cases. Does not cover ConditionalExpressions, for example
+}
+
+function containsKeyword (node) {
+    if (node && node.type && containsKeywordHandlers.hasOwnProperty(node.type)) {
+        return containsKeywordHandlers[node.type](node);
+    }
+}
+
+function containsKeywordCallExpression (node) {
+    return containsKeyword(node.callee);
+}
+
+function containsKeywordIdentifier (node) {
+    return re.test(node.name);
+}
+
+function containsKeywordMemberExpression (node) {
+    if (node.property.type === 'Literal') {
+        // Only care about literals in member expressions
+        return containsKeyword(node.object) || re.test(node.property.value);
+    } else {
+        return containsKeyword(node.object) || containsKeyword(node.property);
+    }
+}
+
 const isVulnHandlers = {
     'CallExpression': isVulnCallExpression,
     'Identifier': isVulnIdentifier,
@@ -32,25 +58,16 @@ const isVulnHandlers = {
     // Not exhaustive, but covers most cases. Does not cover ConditionalExpressions, for example
 }
 
-function containsKeyword (node) {
-    if (node.type === 'Identifier') {
-        if (re.test(node.name)) {
-            return true;
-        }
-    }
-    return
-}
-
-function isVulnerable(node) {
+function isVulnerableType (node) {
     return node && node.type && isVulnHandlers.hasOwnProperty(node.type) && isVulnHandlers[node.type](node);
 }
 
-function isVulnCallExpression(node) {
-    return isVulnerable(node.callee);
+function isVulnCallExpression (node) {
+    return isVulnerableType(node.callee);
 }
 
 function isVulnIdentifier (node) {
-    return containsKeyword(node);
+    return true;
 }
 
 function isVulnLiteral (node) {
@@ -61,7 +78,7 @@ function isVulnLiteral (node) {
 function isVulnMemberExpression (node) {
     // If anything along the path is prohibited, it could be problematic
     // ex: password.toString() could be one, so could user.password
-    return isVulnerable(node.object) || isVulnerable(node.property);
+    return isVulnerableType(node.object) || isVulnerableType(node.property);
 }
 
 module.exports = function(context) {
@@ -72,8 +89,12 @@ module.exports = function(context) {
         "BinaryExpression": function(node) {
             if (node.operator === '==' || node.operator === '===' || node.operator === '!=' || node.operator === '!==') {
 
-                if (isVulnerable(node.left) && isVulnerable(node.right)) {
-                    return context.report(node, "Potential timing attack");
+                if (isVulnerableType(node.left) && isVulnerableType(node.right)) {
+                    if (containsKeyword(node.left)) {
+                        return context.report(node, "Potential timing attack, left side: true");
+                    } else if (containsKeyword(node.right)) {
+                        return context.report(node, "Potential timing attack, right side: true");
+                    }
                 }
             }
         }

--- a/test/detect-possible-timing-attacks.js
+++ b/test/detect-possible-timing-attacks.js
@@ -6,30 +6,71 @@ const tester = new RuleTester();
 const ruleName = 'detect-possible-timing-attacks';
 const Rule = require(`../rules/${ruleName}`);
 
-const valid = 'if (age === 5) {}';
-const invalidLeft = 'if (password === \'mypass\') {}';
-const invalidRigth = 'if (\'mypass\' === password) {}';
-
 
 // We only check with one string "password" and operator "==="
 // to KISS.
 
 tester.run(`${ruleName} (left side)`, Rule, {
-  valid: [{ code: valid }],
+  valid: [
+    { code: 'if (age === 5) {}' },
+    { code: 'if (password === 5) {}' },
+    { code: 'password.toString() === true' },
+    { code: 'if (user.password === true) {}' },
+    { code: 'if (user["password"] === true) {}' }
+  ],
   invalid: [
     {
-      code: invalidLeft,
+      code: 'if (password === \'mypass\') {}',
+      errors: [{ message: 'Potential timing attack, left side: true' }]
+    },
+    {
+      code: 'password.toString() === \'mypass\'',
+      errors: [{ message: 'Potential timing attack, left side: true' }]
+    },
+    {
+      code: 'if (user.password === \'mypass\') {}',
+      errors: [{ message: 'Potential timing attack, left side: true' }]
+    },
+    {
+      code: 'if (user["password"] === \'mypass\') {}',
+      errors: [{ message: 'Potential timing attack, left side: true' }]
+    },
+    {
+      code: 'if (password === getFromDatabase()) {}',
       errors: [{ message: 'Potential timing attack, left side: true' }]
     }
+
   ]
 });
 
 
 tester.run(`${ruleName} (right side)`, Rule, {
-  valid: [{ code: valid }],
+  valid: [
+    { code: 'if (5 === age) {}' },
+    { code: 'if (5 === password) {}' },
+    { code: 'true === password.toString()' },
+    { code: 'if (true === user.password) {}' },
+    { code: 'if (true === user["password"]) {}' }
+  ],
   invalid: [
     {
-      code: invalidRigth,
+      code: 'if (\'mypass\' === password) {}',
+      errors: [{ message: 'Potential timing attack, right side: true' }]
+    },
+    {
+      code: '\'mypass\' === password.toString()',
+      errors: [{ message: 'Potential timing attack, right side: true' }]
+    },
+    {
+      code: 'if (\'mypass\' === user.password) {}',
+      errors: [{ message: 'Potential timing attack, right side: true' }]
+    },
+    {
+      code: 'if (\'mypass\' === user["password"]) {}',
+      errors: [{ message: 'Potential timing attack, right side: true' }]
+    },
+    {
+      code: 'if (getFromDatabase() === password) {}',
       errors: [{ message: 'Potential timing attack, right side: true' }]
     }
   ]


### PR DESCRIPTION
In my usage, I found detect-possible-timing-attack to be essentially toothless. Rarely did I find issues as simple as `password === 'mypass'`. More often, it would be something like, `password.toString() === expectedPassword`, which the old version does not recognize.

Changes
- Runs on BinaryExpressions instead of IfStatements. This way it catches something like `if (checkPassword(a, b)) { ... }` where `checkPassword = (password, expected) => password === expected;`
- Checks identifiers, call expressions, and member expressions for keywords, rather than just identifiers. Now can detect `user.password === 'password'`, `user['password'] === 'password'`, and `password.toString() === 'password'`, for example
- Will only check for keywords if it makes sense. For example, `password === true` does not cause an issue anymore
- Keyword regex matches if a keyword is anywhere within the target, instead of if it exactly equals the target. For example, `expectedPassword === 'password'` will now be flagged
- Removed `auth` as keyword. In practice, it caused many false-positives and any actual positive was already captured by another keyword.