### PR TITLE
Bump safe-regex version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nodesecurity/eslint-plugin-security#readme",
   "dependencies": {
-    "safe-regex": "^1.1.0"
+    "safe-regex": "^2.0.0"
   },
   "devDependencies": {
     "changelog": "1.3.0",


### PR DESCRIPTION
v2.0.0 tweaks safe-regex's heuristic to address some false negatives.