### PR TITLE
Add ESLint meta object with description and category

### DIFF
--- a/rules/detect-buffer-noassert.js
+++ b/rules/detect-buffer-noassert.js
@@ -7,63 +7,69 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var names = [];
-
-module.exports = function(context) {
-
-    "use strict";
-
-    var read = [
-        "readUInt8",
-        "readUInt16LE",
-        "readUInt16BE",
-        "readUInt32LE",
-        "readUInt32BE",
-        "readInt8",
-        "readInt16LE",
-        "readInt16BE",
-        "readInt32LE",
-        "readInt32BE",
-        "readFloatLE",
-        "readFloatBE",
-        "readDoubleL",
-        "readDoubleBE"
-    ];
-
-    var write = [
-        "writeUInt8",
-        "writeUInt16LE",
-        "writeUInt16BE",
-        "writeUInt32LE",
-        "writeUInt32BE",
-        "writeInt8",
-        "writeInt16LE",
-        "writeInt16BE",
-        "writeInt32LE",
-        "writeInt32BE",
-        "writeFloatLE",
-        "writeFloatBE",
-        "writeDoubleLE",
-        "writeDoubleBE"
-    ];
-
-    return {
-        "MemberExpression": function (node) {
-            var index;
-            if (read.indexOf(node.property.name) !== -1) {
-                index = 1;
-            } else if (write.indexOf(node.property.name) !== -1) {
-                index = 2;
-            }
-
-            if (index && node.parent && node.parent.arguments && node.parent.arguments[index] &&  node.parent.arguments[index].value) {
-                var token = context.getTokens(node)[0];
-                return context.report(node, 'Found Buffer.' + node.property.name + ' with noAssert flag set true');
-                
-            }
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect buffer read / write calls that use noAssert set to true",
+            category: "Security"
         }
+    },
+    create(context) {
 
-    };
+        "use strict";
 
+        var read = [
+            "readUInt8",
+            "readUInt16LE",
+            "readUInt16BE",
+            "readUInt32LE",
+            "readUInt32BE",
+            "readInt8",
+            "readInt16LE",
+            "readInt16BE",
+            "readInt32LE",
+            "readInt32BE",
+            "readFloatLE",
+            "readFloatBE",
+            "readDoubleL",
+            "readDoubleBE"
+        ];
+
+        var write = [
+            "writeUInt8",
+            "writeUInt16LE",
+            "writeUInt16BE",
+            "writeUInt32LE",
+            "writeUInt32BE",
+            "writeInt8",
+            "writeInt16LE",
+            "writeInt16BE",
+            "writeInt32LE",
+            "writeInt32BE",
+            "writeFloatLE",
+            "writeFloatBE",
+            "writeDoubleLE",
+            "writeDoubleBE"
+        ];
+
+        return {
+            "MemberExpression": function (node) {
+                var index;
+                if (read.indexOf(node.property.name) !== -1) {
+                    index = 1;
+                } else if (write.indexOf(node.property.name) !== -1) {
+                    index = 2;
+                }
+
+                if (index && node.parent && node.parent.arguments && node.parent.arguments[index] &&  node.parent.arguments[index].value) {
+                    var token = context.getTokens(node)[0];
+                    return context.report(node, 'Found Buffer.' + node.property.name + ' with noAssert flag set true');
+                    
+                }
+            }
+
+        };
+
+    }
 };
 

--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -9,34 +9,39 @@
 
 var names = [];
 
-module.exports = function(context) {
-
-    "use strict";
-
-    return {
-        "CallExpression": function (node) {
-            var token = context.getTokens(node)[0];
-            if (node.callee.name === 'require') {
-                var args = node.arguments[0];
-                if (args && args.type === 'Literal' && args.value === 'child_process') {
-                    if (node.parent.type === 'VariableDeclarator') {
-                        names.push(node.parent.id.name);
-                    } else if (node.parent.type === 'AssignmentExpression' && node.parent.operator === '=') {
-                        names.push(node.parent.left.name);
-                    }
-                    return context.report(node, 'Found require("child_process")');
-                }
-            }
-        },
-        "MemberExpression": function (node) {
-            var token = context.getTokens(node)[0];
-            if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
-                if (node.parent && node.parent.arguments  && node.parent.arguments[0].type !== 'Literal') {
-                    return context.report(node, 'Found child_process.exec() with non Literal first argument');
-                }
-            }
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect instances of child_process",
+            category: "Security"
         }
+    },
+    create(context) {
 
-    };
+        "use strict";
 
+        return {
+            "CallExpression": function (node) {
+                var token = context.getTokens(node)[0];
+                if (node.callee.name === 'require') {
+                    var args = node.arguments[0];
+                    if (args && args.type === 'Literal' && args.value === 'child_process') {
+                        if (node.parent.type === 'VariableDeclarator') {
+                            names.push(node.parent.id.name);
+                        } else if (node.parent.type === 'AssignmentExpression' && node.parent.operator === '=') {
+                            names.push(node.parent.left.name);
+                        }
+                        return context.report(node, 'Found require("child_process")');
+                    }
+                }
+            },
+            "MemberExpression": function (node) {
+                if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
+                    if (node.parent && node.parent.arguments  && node.parent.arguments[0].type !== 'Literal') {
+                        return context.report(node, 'Found child_process.exec() with non Literal first argument');
+                    }
+                }
+            }
+        };
+    }
 };

--- a/rules/detect-disable-mustache-escape.js
+++ b/rules/detect-disable-mustache-escape.js
@@ -1,18 +1,25 @@
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect object.escapeMarkup = false",
+            category: "Security"
+        }
+    },
+    create(context) {
 
-    "use strict";
-    return {
-        "AssignmentExpression": function(node) {
-            if (node.operator === '=') {
-                if (node.left.property) {
-                    if (node.left.property.name == 'escapeMarkup') {
-                        if (node.right.value == false) {
-                            context.report(node, 'Markup escaping disabled.')
+        "use strict";
+        return {
+            "AssignmentExpression": function(node) {
+                if (node.operator === '=') {
+                    if (node.left.property) {
+                        if (node.left.property.name == 'escapeMarkup') {
+                            if (node.right.value == false) {
+                                context.report(node, 'Markup escaping disabled.')
+                            }
                         }
                     }
                 }
             }
-        }
+        };
     }
-
-}
+};

--- a/rules/detect-eval-with-expression.js
+++ b/rules/detect-eval-with-expression.js
@@ -7,15 +7,23 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "identify eval with expression",
+            category: "Security"
+        }
+    },
+    create(context) {
 
     "use strict";
 
-    return {
-        "CallExpression": function(node) {
-            if (node.callee.name === "eval" && node.arguments[0].type !== 'Literal') {
-                context.report(node, "eval with argument of type " + node.arguments[0].type);
+        return {
+            "CallExpression": function(node) {
+                if (node.callee.name === "eval" && node.arguments[0].type !== 'Literal') {
+                    context.report(node, "eval with argument of type " + node.arguments[0].type);
+                }
             }
-        }
-    };
+        };
+    }
 };

--- a/rules/detect-new-buffer.js
+++ b/rules/detect-new-buffer.js
@@ -1,19 +1,28 @@
-module.exports = function (context) {
-    // Detects instances of new Buffer(argument)
-    // where argument is any non literal value.
-    return {
-      "NewExpression": function (node) {
-        if (node.callee.name === 'Buffer' &&
-          node.arguments[0] &&
-          node.arguments[0].type != 'Literal') {
+/**
+ * Detects instances of new Buffer(argument) where argument is any non literal value
+ *
+ */
 
-          return context.report(node, "Found new Buffer");
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect instances of new Buffer(argument) where argument is any non literal value",
+            category: "Security"
         }
-
-
-
-      }
-    };
-
-}
-
+    },
+    create(context) {
+        return {
+            "NewExpression": function (node) {
+                if (node.callee.name === 'Buffer' &&
+                    node.arguments[0] &&
+                    node.arguments[0].type != 'Literal') {
+                    return context.report(node, "Found new Buffer");
+                }
+            }
+        };
+    }
+};

--- a/rules/detect-no-csrf-before-method-override.js
+++ b/rules/detect-no-csrf-before-method-override.js
@@ -8,32 +8,40 @@
 //------------------------------------------------------------------------------
 
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "Check and see if CSRF middleware is before methodOverride.",
+            category: "Security"
+        }
+    },
+    create(context) {
 
-    "use strict";
-    var csrf = false;
+        "use strict";
+        var csrf = false;
 
-    return {
-        "CallExpression": function(node) {
-            var token = context.getTokens(node)[0],
-                nodeType = token.type,
-                nodeValue = token.value;
+        return {
+            "CallExpression": function(node) {
+                var token = context.getTokens(node)[0],
+                    nodeType = token.type,
+                    nodeValue = token.value;
 
-            if (nodeValue === "express") {
-                if (!node.callee || !node.callee.property) {
-                    return;
-                }
+                if (nodeValue === "express") {
+                    if (!node.callee || !node.callee.property) {
+                        return;
+                    }
 
-                if (node.callee.property.name === "methodOverride" && csrf) {
-                    context.report(node, "express.csrf() middleware found before express.methodOverride()");
-                }
-                if (node.callee.property.name === "csrf") {
-                    // Keep track of found CSRF
-                    csrf = true;
+                    if (node.callee.property.name === "methodOverride" && csrf) {
+                        context.report(node, "express.csrf() middleware found before express.methodOverride()");
+                    }
+                    if (node.callee.property.name === "csrf") {
+                        // Keep track of found CSRF
+                        csrf = true;
+                    }
                 }
             }
-        }
-    };
+        };
 
+    }
 };
 

--- a/rules/detect-non-literal-fs-filename.js
+++ b/rules/detect-non-literal-fs-filename.js
@@ -7,43 +7,50 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var names = [];
 var fsMetaData = require('./data/fsFunctionData.json');
 var funcNames = Object.keys(fsMetaData);
 
-module.exports = function(context) {
-
-    "use strict";
-
-    return {
-        "MemberExpression": function (node) {
-            var result = [];
-            if (funcNames.indexOf(node.property.name) !== -1) {
-                var meta = fsMetaData[node.property.name];
-                var args = node.parent.arguments;
-                meta.forEach(function (i) {
-                    if (args && args.length > i) {
-                        if (args[i].type !== 'Literal') {
-                            result.push(i);
-                        }
-                    }
-                });
-            }
-
-            if (result.length > 0) {
-                var token = context.getTokens(node)[0];
-                return context.report(node, 'Found fs.' + node.property.name + ' with non literal argument at index ' + result.join(','));
-            }
-
-
-            /*
-            if (node.parent && node.parent.arguments && node.parent.arguments[index].value) {
-                return context.report(node, 'found Buffer.' + node.property.name + ' with noAssert flag set true');
-
-            }
-            */
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect calls to fs functions that take a non Literal value as the filename parameter",
+            category: "Security"
         }
+    },
+    create(context) {
 
-    };
+        "use strict";
 
+        return {
+            "MemberExpression": function (node) {
+                var result = [];
+                if (funcNames.indexOf(node.property.name) !== -1) {
+                    var meta = fsMetaData[node.property.name];
+                    var args = node.parent.arguments;
+                    meta.forEach(function (i) {
+                        if (args && args.length > i) {
+                            if (args[i].type !== 'Literal') {
+                                result.push(i);
+                            }
+                        }
+                    });
+                }
+
+                if (result.length > 0) {
+                    var token = context.getTokens(node)[0];
+                    return context.report(node, 'Found fs.' + node.property.name + ' with non literal argument at index ' + result.join(','));
+                }
+
+
+                /*
+                if (node.parent && node.parent.arguments && node.parent.arguments[index].value) {
+                    return context.report(node, 'found Buffer.' + node.property.name + ' with noAssert flag set true');
+
+                }
+                */
+            }
+
+        };
+
+    }
 };

--- a/rules/detect-non-literal-regexp.js
+++ b/rules/detect-non-literal-regexp.js
@@ -8,21 +8,28 @@
 //------------------------------------------------------------------------------
 
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect RegExp's created from non-literal strings",
+            category: "Security"
+        }
+    },
+    create(context) {
 
         "use strict";
 
         return {
-                "NewExpression": function(node) {
-                        if (node.callee.name === 'RegExp') {
-                                var args = node.arguments;
-                                if (args && args.length > 0 && args[0].type !== 'Literal') {
-                                        var token = context.getTokens(node)[0];
-                                        return context.report(node, 'Found non-literal argument to RegExp Constructor');
-                                }
-                        }
-
+            "NewExpression": function(node) {
+                if (node.callee.name === 'RegExp') {
+                    var args = node.arguments;
+                    if (args && args.length > 0 && args[0].type !== 'Literal') {
+                        return context.report(node, 'Found non-literal argument to RegExp Constructor');
+                    }
                 }
 
-        }
-}
+            }
+
+        };
+    }
+};

--- a/rules/detect-non-literal-require.js
+++ b/rules/detect-non-literal-require.js
@@ -7,23 +7,30 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect calls to require with non-literal argument",
+            category: "Security"
+        }
+    },
+    create(context) {
 
-    "use strict";
+        "use strict";
 
-    return {
-        "CallExpression": function (node) {
-            if (node.callee.name === 'require') {
-                var args = node.arguments;
-                if (args && args.length > 0 && args[0].type !== 'Literal') {
-                    var token = context.getTokens(node)[0];
-                    return context.report(node, 'Found non-literal argument in require');
+        return {
+            "CallExpression": function (node) {
+                if (node.callee.name === 'require') {
+                    var args = node.arguments;
+                    if (args && args.length > 0 && args[0].type !== 'Literal') {
+                        var token = context.getTokens(node)[0];
+                        return context.report(node, 'Found non-literal argument in require');
+                    }
                 }
+
             }
 
-        }
+        };
 
-    };
-
+    }
 };
-

--- a/rules/detect-object-injection.js
+++ b/rules/detect-object-injection.js
@@ -7,7 +7,6 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var Sinks = [];
 function getSerialize (fn, decycle) {
   var seen = [], keys = [];
   decycle = decycle || function(key, value) {
@@ -44,14 +43,18 @@ function stringify(obj, fn, spaces, decycle) {
   return JSON.stringify(obj, getSerialize(fn, decycle), spaces);
 }
 
-stringify.getSerialize = getSerialize;module.exports = function(context) {
+stringify.getSerialize = getSerialize;
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect instances of var[var]",
+            category: "Security"
+        }
+    }, 
+    create(context) {
 
         "use strict";
-
-var isChanged = false;
-
-
-
         return {
             "MemberExpression": function(node) {
 
@@ -59,14 +62,12 @@ var isChanged = false;
                     var token = context.getTokens(node)[0];
                     if (node.property.type === 'Identifier') {
                         if (node.parent.type === 'VariableDeclarator') {
-   context.report(node, 'Variable Assigned to Object Injection Sink');
-    
+                            context.report(node, 'Variable Assigned to Object Injection Sink');
                         } else if (node.parent.type === 'CallExpression') {
                         //    console.log(node.parent)
-  context.report(node, 'Function Call Object Injection Sink');
+                            context.report(node, 'Function Call Object Injection Sink');
                         } else {
-                        context.report(node, 'Generic Object Injection Sink');
-    
+                            context.report(node, 'Generic Object Injection Sink');
                         }
 
                     }
@@ -76,4 +77,5 @@ var isChanged = false;
 
         };
     }
+};
 

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -28,33 +28,41 @@ function containsKeyword (node) {
         return
 }
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect potential hotspot string comparisons",
+            category: "Security"
+        }
+    },
+    create(context) {
 
-    "use strict";
+        "use strict";
 
-    return {
-        "IfStatement": function(node) {
-            if (node.test && node.test.type === 'BinaryExpression') {
-                if (node.test.operator === '==' || node.test.operator === '===' || node.test.operator === '!=' || node.test.operator === '!==') {
+        return {
+            "IfStatement": function(node) {
+                if (node.test && node.test.type === 'BinaryExpression') {
+                    if (node.test.operator === '==' || node.test.operator === '===' || node.test.operator === '!=' || node.test.operator === '!==') {
 
-                    var token = context.getTokens(node)[0];
+                        var token = context.getTokens(node)[0];
 
-                    if (node.test.left) {
-                    var left = containsKeyword(node.test.left);
-                        if (left) {
-                            return context.report(node, "Potential timing attack, left side: " + left);
+                        if (node.test.left) {
+                        var left = containsKeyword(node.test.left);
+                            if (left) {
+                                return context.report(node, "Potential timing attack, left side: " + left);
+                            }
                         }
-                    }
 
-                    if (node.test.right) {
-                    var right = containsKeyword(node.test.right);
-                        if (right) {
-                            return context.report(node, "Potential timing attack, right side: " + right);
+                        if (node.test.right) {
+                        var right = containsKeyword(node.test.right);
+                            if (right) {
+                                return context.report(node, "Potential timing attack, right side: " + right);
+                            }
                         }
                     }
                 }
             }
-        }
-    };
+        };
 
+    }
 };

--- a/rules/detect-pseudoRandomBytes.js
+++ b/rules/detect-pseudoRandomBytes.js
@@ -7,18 +7,25 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
+module.exports = {
+    meta: {
+        docs: {
+            description: "detect crypto.pseudoRandomBytes cause it's not cryptographical strong",
+            category: "Security"
+        }
+    },
+    create(context) {
 
     "use strict";
 
-    return {
-        "MemberExpression": function (node) {
-            if (node.property.name === 'pseudoRandomBytes') {
-                var token = context.getTokens(node)[0];
-                return context.report(node, 'Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers');
+        return {
+            "MemberExpression": function (node) {
+                if (node.property.name === 'pseudoRandomBytes') {
+                    return context.report(node, 'Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers');
+                }
             }
-        }
 
-    };
+        };
 
+    }
 };

--- a/rules/detect-unsafe-regex.js
+++ b/rules/detect-unsafe-regex.js
@@ -8,30 +8,37 @@ var safe = require('safe-regex');
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
-
-    "use strict";
-
-    return {
-        "Literal": function(node) {
-            var token = context.getTokens(node)[0],
-                nodeType = token.type,
-                nodeValue = token.value;
-
-            if (nodeType === "RegularExpression") {
-                if (!safe(nodeValue)) {
-                    context.report(node, "Unsafe Regular Expression");
-                }
-            }
-        },
-        "NewExpression": function(node) {
-            if (node.callee.name == "RegExp" && node.arguments && node.arguments.length > 0 && node.arguments[0].type == "Literal") {
-                if (!safe(node.arguments[0].value)) {
-                    context.report(node, "Unsafe Regular Expression (new RegExp)");
-                }
-            }
+module.exports = {
+    meta: {
+        docs: {
+            description: "check if the regex is evil or not using the safe-regex module",
+            category: "Security"
         }
-    };
+    },
+    create(context) {
 
+        "use strict";
+
+        return {
+            "Literal": function(node) {
+                var token = context.getTokens(node)[0],
+                    nodeType = token.type,
+                    nodeValue = token.value;
+
+                if (nodeType === "RegularExpression") {
+                    if (!safe(nodeValue)) {
+                        context.report(node, "Unsafe Regular Expression");
+                    }
+                }
+            },
+            "NewExpression": function(node) {
+                if (node.callee.name == "RegExp" && node.arguments && node.arguments.length > 0 && node.arguments[0].type == "Literal") {
+                    if (!safe(node.arguments[0].value)) {
+                        context.report(node, "Unsafe Regular Expression (new RegExp)");
+                    }
+                }
+            }
+        };
+
+    }
 };
-


### PR DESCRIPTION
Hi team,
We use your plugin at Codacy for automated code reviews :)
We use ESLint's `meta` object field to add descriptions to the rules in [our wrapper](https://github.com/codacy/codacy-eslint)
This PR adds the descriptions to all the rules taken from the comments in the source files.

Hope this will be accepted.
Lorenzo