### PR TITLE
No need for `plugins` since the `recommended` config already includes it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ This project will help identify potential security hotspots, but finds a lot of 
 Add the following to your `.eslintrc` file:
 
 ```js
-"plugins": [
-  "security"
-],
 "extends": [
   "plugin:security/recommended"
 ]


### PR DESCRIPTION
The `plugins` array is only needed if one is not using the config (or a config which doesn't add to `plugins`).