### PR TITLE
chore: add `eslint-plugin-eslint-plugin`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": [
     "eslint:recommended",
-    "prettier"
+    "prettier",
+    "plugin:eslint-plugin/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": "latest"
@@ -9,5 +10,17 @@
   "env": {
     "node": true,
     "es2020": true
+  },
+  "rules": {
+    "eslint-plugin/prefer-message-ids": "off", // TODO: enable
+    "eslint-plugin/require-meta-docs-url": [
+      "error",
+      {
+        "pattern":
+          "https://github.com/nodesecurity/eslint-plugin-security#{{name}}",
+      },
+    ],
+    "eslint-plugin/require-meta-schema": "off", // TODO: enable
+    "eslint-plugin/require-meta-type": "off"// TODO: enable
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eslint-plugin-security",
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15,6 +16,7 @@
         "eslint": "^8.11.0",
         "eslint-config-nodesecurity": "^1.3.1",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-eslint-plugin": "^5.0.2",
         "lint-staged": "^12.3.7",
         "mocha": "^9.2.2",
         "prettier": "^2.6.2",
@@ -1582,6 +1584,22 @@
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.2.tgz",
+      "integrity": "sha512-i1g9NpZXaBu3E+ufXHn9muW67PGDxxPpAVDUrAWWS9dG7y5wtxqEhnvookb+O+r2ByLjMJ+tyGizu5TyueBmbw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -10032,6 +10050,16 @@
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-eslint-plugin": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.2.tgz",
+      "integrity": "sha512-i1g9NpZXaBu3E+ufXHn9muW67PGDxxPpAVDUrAWWS9dG7y5wtxqEhnvookb+O+r2ByLjMJ+tyGizu5TyueBmbw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.2.0"
+      }
     },
     "eslint-plugin-hapi": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8.11.0",
     "eslint-config-nodesecurity": "^1.3.1",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-eslint-plugin": "^5.0.2",
     "lint-staged": "^12.3.7",
     "mocha": "^9.2.2",
     "prettier": "^2.6.2",

--- a/rules/detect-buffer-noassert.js
+++ b/rules/detect-buffer-noassert.js
@@ -72,7 +72,7 @@ module.exports = {
         }
 
         if (index && node.parent && node.parent.arguments && node.parent.arguments[index] && node.parent.arguments[index].value) {
-          return context.report(node, `Found Buffer.${node.property.name} with noAssert flag set true`);
+          return context.report({ node: node, message: `Found Buffer.${node.property.name} with noAssert flag set true` });
         }
       },
     };

--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -21,7 +21,7 @@ module.exports = {
       description: 'Detect instances of "child_process" & non-literal "exec()" calls.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/avoid-command-injection-node.md',
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-child-process',
     },
   },
   create: function (context) {
@@ -35,14 +35,14 @@ module.exports = {
             } else if (node.parent.type === 'AssignmentExpression' && node.parent.operator === '=') {
               names.push(node.parent.left.name);
             }
-            return context.report(node, 'Found require("child_process")');
+            return context.report({ node: node, message: 'Found require("child_process")' });
           }
         }
       },
       MemberExpression: function (node) {
         if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
           if (node.parent && node.parent.arguments.length && node.parent.arguments[0].type !== 'Literal') {
-            return context.report(node, 'Found child_process.exec() with non Literal first argument');
+            return context.report({ node: node, message: 'Found child_process.exec() with non Literal first argument' });
           }
         }
       },

--- a/rules/detect-disable-mustache-escape.js
+++ b/rules/detect-disable-mustache-escape.js
@@ -7,8 +7,8 @@ module.exports = {
       description: 'Detects "object.escapeMarkup = false", which can be used with some template engines to disable escaping of HTML entities.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-disable-mustache-escape'
-    }
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-disable-mustache-escape',
+    },
   },
   create: function (context) {
     return {
@@ -17,12 +17,12 @@ module.exports = {
           if (node.left.property) {
             if (node.left.property.name === 'escapeMarkup') {
               if (node.right.value === false) {
-                context.report(node, 'Markup escaping disabled.');
+                context.report({ node: node, message: 'Markup escaping disabled.' });
               }
             }
           }
         }
-      }
+      },
     };
-  }
+  },
 };

--- a/rules/detect-eval-with-expression.js
+++ b/rules/detect-eval-with-expression.js
@@ -16,16 +16,16 @@ module.exports = {
       description: 'Detects "eval(variable)" which can allow an attacker to run arbitrary code inside your process.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-eval-with-expression'
-    }
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-eval-with-expression',
+    },
   },
   create: function (context) {
     return {
       CallExpression: function (node) {
         if (node.callee.name === 'eval' && node.arguments[0].type !== 'Literal') {
-          context.report(node, `eval with argument of type ${node.arguments[0].type}`);
+          context.report({ node: node, message: `eval with argument of type ${node.arguments[0].type}` });
         }
-      }
+      },
     };
-  }
+  },
 };

--- a/rules/detect-new-buffer.js
+++ b/rules/detect-new-buffer.js
@@ -7,16 +7,16 @@ module.exports = {
       description: 'Detect instances of new Buffer(argument) where argument is any non-literal value.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/README.md'
-    }
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-new-buffer',
+    },
   },
   create: function (context) {
     return {
       NewExpression: function (node) {
         if (node.callee.name === 'Buffer' && node.arguments[0] && node.arguments[0].type !== 'Literal') {
-          return context.report(node, 'Found new Buffer');
+          return context.report({ node: node, message: 'Found new Buffer' });
         }
-      }
+      },
     };
-  }
+  },
 };

--- a/rules/detect-no-csrf-before-method-override.js
+++ b/rules/detect-no-csrf-before-method-override.js
@@ -16,7 +16,7 @@ module.exports = {
       description: 'Detects Express "csrf" middleware setup before "method-override" middleware.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/bypass-connect-csrf-protection-by-abusing.md',
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-no-csrf-before-method-override',
     },
   },
   create: function (context) {
@@ -24,7 +24,7 @@ module.exports = {
 
     return {
       CallExpression: function (node) {
-        const token = context.getTokens(node)[0];
+        const token = context.getSourceCode().getTokens(node)[0];
         const nodeValue = token.value;
 
         if (nodeValue === 'express') {
@@ -33,7 +33,7 @@ module.exports = {
           }
 
           if (node.callee.property.name === 'methodOverride' && csrf) {
-            context.report(node, 'express.csrf() middleware found before express.methodOverride()');
+            context.report({ node: node, message: 'express.csrf() middleware found before express.methodOverride()' });
           }
           if (node.callee.property.name === 'csrf') {
             // Keep track of found CSRF

--- a/rules/detect-non-literal-fs-filename.js
+++ b/rules/detect-non-literal-fs-filename.js
@@ -39,7 +39,7 @@ module.exports = {
         }
 
         if (result.length > 0) {
-          return context.report(node, `Found fs.${node.property.name} with non literal argument at index ${result.join(',')}`);
+          return context.report({ node: node, message: `Found fs.${node.property.name} with non literal argument at index ${result.join(',')}` });
         }
 
         /*

--- a/rules/detect-non-literal-regexp.js
+++ b/rules/detect-non-literal-regexp.js
@@ -16,7 +16,7 @@ module.exports = {
       description: 'Detects "RegExp(variable)", which might allow an attacker to DOS your server with a long-running regular expression.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/regular-expression-dos-and-node.md',
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-regexp',
     },
   },
   create: function (context) {
@@ -25,7 +25,7 @@ module.exports = {
         if (node.callee.name === 'RegExp') {
           const args = node.arguments;
           if (args && args.length > 0 && args[0].type !== 'Literal') {
-            return context.report(node, 'Found non-literal argument to RegExp Constructor');
+            return context.report({ node: node, message: 'Found non-literal argument to RegExp Constructor' });
           }
         }
       },

--- a/rules/detect-non-literal-require.js
+++ b/rules/detect-non-literal-require.js
@@ -28,7 +28,7 @@ module.exports = {
             (args && args.length > 0 && args[0].type === 'TemplateLiteral' && args[0].expressions.length > 0) ||
             (args[0].type !== 'TemplateLiteral' && args[0].type !== 'Literal')
           ) {
-            return context.report(node, 'Found non-literal argument in require');
+            return context.report({ node: node, message: 'Found non-literal argument in require' });
           }
         }
       },

--- a/rules/detect-object-injection.js
+++ b/rules/detect-object-injection.js
@@ -58,7 +58,7 @@ module.exports = {
       description: 'Detects "variable[key]" as a left- or right-hand assignment operand.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md',
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection',
     },
   },
   create: function (context) {
@@ -67,11 +67,11 @@ module.exports = {
         if (node.computed === true) {
           if (node.property.type === 'Identifier') {
             if (node.parent.type === 'VariableDeclarator') {
-              context.report(node, 'Variable Assigned to Object Injection Sink');
+              context.report({ node: node, message: 'Variable Assigned to Object Injection Sink' });
             } else if (node.parent.type === 'CallExpression') {
-              context.report(node, 'Function Call Object Injection Sink');
+              context.report({ node: node, message: 'Function Call Object Injection Sink' });
             } else {
-              context.report(node, 'Generic Object Injection Sink');
+              context.report({ node: node, message: 'Generic Object Injection Sink' });
             }
           }
         }

--- a/rules/detect-possible-timing-attacks.js
+++ b/rules/detect-possible-timing-attacks.js
@@ -29,8 +29,8 @@ module.exports = {
       description: 'Detects insecure comparisons (`==`, `!=`, `!==` and `===`), which check input sequentially.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-possible-timing-attacks'
-    }
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-possible-timing-attacks',
+    },
   },
   create: function (context) {
     return {
@@ -40,19 +40,19 @@ module.exports = {
             if (node.test.left) {
               const left = containsKeyword(node.test.left);
               if (left) {
-                return context.report(node, `Potential timing attack, left side: ${left}`);
+                return context.report({ node: node, message: `Potential timing attack, left side: ${left}` });
               }
             }
 
             if (node.test.right) {
               const right = containsKeyword(node.test.right);
               if (right) {
-                return context.report(node, `Potential timing attack, right side: ${right}`);
+                return context.report({ node: node, message: `Potential timing attack, right side: ${right}` });
               }
             }
           }
         }
-      }
+      },
     };
-  }
+  },
 };

--- a/rules/detect-pseudoRandomBytes.js
+++ b/rules/detect-pseudoRandomBytes.js
@@ -16,14 +16,14 @@ module.exports = {
       description: 'Detects if "pseudoRandomBytes()" is in use, which might not give you the randomness you need and expect.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-pseudorandombytes',
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-pseudoRandomBytes',
     },
   },
   create: function (context) {
     return {
       MemberExpression: function (node) {
         if (node.property.name === 'pseudoRandomBytes') {
-          return context.report(node, 'Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers');
+          return context.report({ node: node, message: 'Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers' });
         }
       },
     };

--- a/rules/detect-unsafe-regex.js
+++ b/rules/detect-unsafe-regex.js
@@ -22,29 +22,29 @@ module.exports = {
       description: 'Locates potentially unsafe regular expressions, which may take a very long time to run, blocking the event loop.',
       category: 'Possible Security Vulnerability',
       recommended: true,
-      url: 'https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/regular-expression-dos-and-node.md'
-    }
+      url: 'https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex',
+    },
   },
   create: function (context) {
     return {
       Literal: function (node) {
-        const token = context.getTokens(node)[0];
+        const token = context.getSourceCode().getTokens(node)[0];
         const nodeType = token.type;
         const nodeValue = token.value;
 
         if (nodeType === 'RegularExpression') {
           if (!safe(nodeValue)) {
-            context.report(node, 'Unsafe Regular Expression');
+            context.report({ node: node, message: 'Unsafe Regular Expression' });
           }
         }
       },
       NewExpression: function (node) {
         if (node.callee.name === 'RegExp' && node.arguments && node.arguments.length > 0 && node.arguments[0].type === 'Literal') {
           if (!safe(node.arguments[0].value)) {
-            context.report(node, 'Unsafe Regular Expression (new RegExp)');
+            context.report({ node: node, message: 'Unsafe Regular Expression (new RegExp)' });
           }
         }
-      }
+      },
     };
-  }
+  },
 };


### PR DESCRIPTION
Includes:

* Adds [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) which is recommended for all [ESLint plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
* Enables the `recommended` rules from this plugin except for a few with more violations which can be enabled later
* Autofixed all violations
   * Inconsistent / missing rule doc URLs
   * Old-style arguments for `context.report()`
 