### PR TITLE
fix: Avoid TypeError when exec stub is used with no arguments

### DIFF
--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -41,7 +41,7 @@ module.exports = {
       },
       MemberExpression: function (node) {
         if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
-          if (node.parent && node.parent.arguments.length && node.parent.arguments[0].type !== 'Literal') {
+          if (node.parent && node.parent.arguments && node.parent.arguments.length && node.parent.arguments[0].type !== 'Literal') {
             return context.report({ node: node, message: 'Found child_process.exec() with non Literal first argument' });
           }
         }

--- a/test/detect-child-process.js
+++ b/test/detect-child-process.js
@@ -21,5 +21,9 @@ tester.run(ruleName, rule, {
       code: "var child = require('child_process'); child.exec()",
       errors: [{ message: 'Found require("child_process")' }],
     },
+    {
+      code: "var child = sinon.stub(require('child_process')); child.exec.returns({});",
+      errors: [{ message: 'Found require("child_process")' }],
+    },
   ],
 });


### PR DESCRIPTION
This extends the fix in 7f97815accf6bcd87de73c32a967946b1b3b0530

In some situations, such as code using a sinon stub, a TypeError is thrown as the AST node has no 'arguments' property.

Closes 69
Refs 69